### PR TITLE
Inject downloader

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/sampointer/digg/command"
-	"github.com/sampointer/digg/fetcher"
+	"github.com/sampointer/digg/manifest"
 )
 
 var cfgFile string
@@ -42,14 +42,8 @@ See https://support.google.com/a/answer/10026322?hl=en for more information.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	Run: func(cmd *cobra.Command, args []string) {
-		docs, err := fetcher.Fetch()
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-
 		for _, arg := range args {
-			res, err := command.Lookup(arg, docs)
+			res, err := command.Lookup(arg, manifest.GetManifest())
 			if err != nil {
 				fmt.Println(err)
 				return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/sampointer/digg/command"
+	"github.com/sampointer/digg/fetcher"
 )
 
 var cfgFile string
@@ -41,8 +42,14 @@ See https://support.google.com/a/answer/10026322?hl=en for more information.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	Run: func(cmd *cobra.Command, args []string) {
+		docs, err := fetcher.Fetch()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
 		for _, arg := range args {
-			res, err := command.Lookup(arg)
+			res, err := command.Lookup(arg, docs)
 			if err != nil {
 				fmt.Println(err)
 				return

--- a/command/lookup.go
+++ b/command/lookup.go
@@ -1,24 +1,19 @@
 package command
 
 import (
-	"github.com/sampointer/digg/ranges"
-
+	"io"
 	"net"
-	"net/http"
 	"strings"
+
+	"github.com/sampointer/digg/ranges"
 )
 
 //Lookup returns Prefixes the ranges of which include the passed IP address
-func Lookup(q string) ([]ranges.Prefix, error) {
+func Lookup(q string, docs []io.Reader) ([]ranges.Prefix, error) {
 	var r []ranges.Prefix
 
-	urls := []string{
-		"https://www.gstatic.com/ipranges/goog.json",
-		"https://www.gstatic.com/ipranges/cloud.json",
-	}
-
-	for _, url := range urls {
-		l, err := lookup(q, url)
+	for _, doc := range docs {
+		l, err := lookup(q, doc)
 		if err != nil {
 			return r, err
 		}
@@ -30,16 +25,10 @@ func Lookup(q string) ([]ranges.Prefix, error) {
 	return r, nil
 }
 
-func lookup(q string, url string) ([]ranges.Prefix, error) {
-	var client http.Client
+func lookup(q string, doc io.Reader) ([]ranges.Prefix, error) {
 	var prefixes []ranges.Prefix
 
-	resp, err := client.Get(url)
-	if err != nil {
-		return nil, err
-	}
-
-	r, err := ranges.New(resp.Body)
+	r, err := ranges.New(doc)
 	if err != nil {
 		return nil, err
 	}

--- a/command/lookup_test.go
+++ b/command/lookup_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"testing"
 
+	"github.com/sampointer/digg/fetcher"
 	"github.com/sampointer/digg/ranges"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,10 @@ func TestLookup(t *testing.T) {
 			IPV4Prefix: "8.8.8.0/24",
 		}
 
-		p, err := Lookup(ipv4)
+		docs, err := fetcher.Fetch()
+		require.NoError(t, err)
+
+		p, err := Lookup(ipv4, docs)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(p))
 		require.Equal(t, prefix, p[0])
@@ -35,7 +39,10 @@ func TestLookup(t *testing.T) {
 			Service:    "Google Cloud",
 		}
 
-		p, err := Lookup(ipv6)
+		docs, err := fetcher.Fetch()
+		require.NoError(t, err)
+
+		p, err := Lookup(ipv6, docs)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(p))
 		require.Equal(t, prefix0, p[0])

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -1,0 +1,26 @@
+package fetcher
+
+import (
+	"io"
+	"net/http"
+)
+
+//Fetch downloads the service tags manifest
+func Fetch() ([]io.Reader, error) {
+	urls := []string{
+		"https://www.gstatic.com/ipranges/goog.json",
+		"https://www.gstatic.com/ipranges/cloud.json",
+	}
+
+	var client http.Client
+	var docs []io.Reader
+
+	for _, u := range urls {
+		doc, err := client.Get(u)
+		if err != nil {
+			docs = append(docs, doc.Body)
+		}
+	}
+
+	return docs, nil
+}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -18,8 +18,9 @@ func Fetch() ([]io.Reader, error) {
 	for _, u := range urls {
 		doc, err := client.Get(u)
 		if err != nil {
-			docs = append(docs, doc.Body)
+			return docs, err
 		}
+		docs = append(docs, doc.Body)
 	}
 
 	return docs, nil

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -1,0 +1,23 @@
+package fetcher
+
+import (
+	"io/ioutil"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetcher(t *testing.T) {
+	f, err := Fetch()
+	require.NoError(t, err)
+
+	for _, doc := range f {
+		d, err := ioutil.ReadAll(doc)
+		require.NoError(t, err)
+
+		re := regexp.MustCompile("syncToken")
+		res := re.FindString(string(d))
+		require.NotZero(t, res)
+	}
+}

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -11,6 +11,7 @@ import (
 func TestFetcher(t *testing.T) {
 	f, err := Fetch()
 	require.NoError(t, err)
+	require.Equal(t, 2, len(f))
 
 	for _, doc := range f {
 		d, err := ioutil.ReadAll(doc)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,0 +1,73 @@
+package manifest
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sampointer/digg/fetcher"
+)
+
+type manifest struct {
+	docs []string
+	lock sync.Mutex
+}
+
+var m manifest
+
+func init() {
+	m.update()
+	m.cron()
+}
+
+//GetManifest is a thread safe Getter for the manifest document
+func GetManifest() []io.Reader {
+	var docs []io.Reader
+
+	m.lock.Lock()
+	for _, doc := range m.docs {
+		docs = append(docs, strings.NewReader(doc))
+	}
+	m.lock.Unlock()
+	return docs
+}
+
+func (m *manifest) cron() {
+	ticker := time.NewTicker(1 * time.Hour)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				fmt.Println("update of Google manifest begins")
+				m.update()
+				fmt.Println("update of Google manifest ends")
+			}
+		}
+	}()
+}
+
+func (m *manifest) update() {
+	var newDocs []string
+
+	docs, err := fetcher.Fetch()
+	if err != nil {
+		fmt.Println("failed to update Google manifest")
+		return
+	}
+
+	for _, doc := range docs {
+		b, err := ioutil.ReadAll(doc)
+		if err != nil {
+			fmt.Println("failed to read Google manifest during update")
+			return
+		}
+		newDocs = append(newDocs, string(b))
+	}
+
+	m.lock.Lock()
+	m.docs = newDocs
+	m.lock.Unlock()
+}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -1,0 +1,21 @@
+package manifest
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetManifest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("manifests are valid JSON", func(t *testing.T) {
+		for _, doc := range GetManifest() {
+			res, err := ioutil.ReadAll(doc)
+			require.NoError(t, err)
+			require.True(t, json.Valid(res))
+		}
+	})
+}


### PR DESCRIPTION
Introduce the manifest package in order that this module can be consumed as a library without each call to command.Lookup() fetching the manifest. In particular, as part of a web service, this moves the periodic downloading of the manifest outside of the request cycle and the initial download of the manifest to initialisation.